### PR TITLE
feat(ec2): add single EC2 module wired to vpc with SSM+Nginx user-data

### DIFF
--- a/.github/workflows/tf-ci.yml
+++ b/.github/workflows/tf-ci.yml
@@ -60,12 +60,21 @@ jobs:
       - name: Run tfsec (fail on HIGH)
         run: tfsec --no-color --minimum-severity HIGH --soft-fail .
 
+
       # ---------- OIDC（PR只读） ----------
       - name: Configure AWS via OIDC (plan)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_GHA_PLAN_ROLE_ARN }}   # ← 建议改用 Secret
           aws-region: us-east-1
+
+      - name: Who am I (AWS)
+        run: aws sts get-caller-identity
+
+      - name: S3 state sanity check
+        run: |
+          aws s3api head-bucket --bucket my-terraform-state-daqula || true
+          aws s3api head-object --bucket my-terraform-state-daqula --key dev/terraform.tfstate || true
 
       # ---------- Terraform（envs/dev） ----------
       - name: Terraform Init (envs/dev)

--- a/.github/workflows/tf-ci.yml
+++ b/.github/workflows/tf-ci.yml
@@ -14,6 +14,9 @@ env:
   TF_INPUT: "false"
   TF_IN_AUTOMATION: "1"
   AWS_REGION: us-east-1
+  STATE_BUCKET: my-terraform-state-daqula
+  STATE_KEY: dev/terraform.tfstate
+  USE_APPLY_FOR_PR_PLAN: "false"
 
 concurrency:
   group: terraform-${{ github.ref }}
@@ -65,8 +68,8 @@ jobs:
       - name: Configure AWS via OIDC (plan)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_GHA_PLAN_ROLE_ARN }}   # ← 建议改用 Secret
-          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_GHA_PLAN_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Who am I (AWS)
         run: aws sts get-caller-identity
@@ -142,7 +145,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_GHA_APPLY_ROLE_ARN }}   # ← 建议改用 Secret
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform Init
         run: terraform -chdir=envs/dev init
@@ -173,7 +176,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_GHA_APPLY_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform Init
         run: terraform -chdir=envs/dev init

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -34,7 +34,7 @@ module "iam_gha_oidc" {
 }
 
 
-/*
+
 module "ec2" {
   source        = "../../modules/ec2"
   name_prefix   = var.name_prefix
@@ -43,11 +43,10 @@ module "ec2" {
   instance_type = var.ec2_instance_type
   ami_id        = var.ami_id
 
-  count = var.enable_ec2 ? 1 : 0
 }
 
 
-
+/*
 module "alb" {
   source            = "../../modules/alb"
   vpc_id            = module.vpc.vpc_id

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -1,15 +1,4 @@
 
-/*
-locals {
-
-  ec2_instance_ids = [module.ec2.instance_id]
-
-
-}
-*/
-
-
-
 module "vpc" {
   source          = "../../modules/vpc"
   name_prefix     = var.name_prefix
@@ -46,33 +35,35 @@ module "ec2" {
 }
 
 
-/*
+locals {
+  alb_enabled = var.enable_alb ? { main = true } : {}
+}
 module "alb" {
+  for_each          = local.alb_enabled
   source            = "../../modules/alb"
   vpc_id            = module.vpc.vpc_id
   public_subnet_ids = module.vpc.public_subnet_ids
 
   # 当前阶段：用实例ID列表对接
-  target_instance_ids = local.ec2_instance_ids
+  target_instance_ids = module.ec2.instance_ids
 
   # 未来切到 ASG 时：把上面这一行删掉/注释掉，并传 asg_name
   # asg_name          = module.asg.name
-
-  count = var.enable_alb ? 1 : 0
 
   tags = { env = "dev", app = "demo" }
 }
 
 # 让 EC2 只接受来自 ALB 的 80 端口（如 EC2 模块未内置规则，则在此补一条）
 resource "aws_security_group_rule" "web_from_alb" {
+  count                    = var.enable_alb ? 1 : 0
   type                     = "ingress"
   from_port                = 80
   to_port                  = 80
   protocol                 = "tcp"
-  security_group_id        = module.ec2.security_group_id # 目标：EC2 SG（由 EC2 子模块输出）
-  source_security_group_id = module.alb.alb_sg_id         # 源：ALB SG（由 ALB 子模块输出）
+  security_group_id        = module.ec2.security_group_id                         # 目标：EC2 SG（由 EC2 子模块输出）
+  source_security_group_id = var.enable_alb ? module.alb["main"].alb_sg_id : null # 源：ALB SG（由 ALB 子模块输出）
 }
-
+/*
 module "rds" {
   source             = "../../modules/rds"
   vpc_id             = module.vpc.vpc_id

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -27,7 +27,7 @@ module "iam_gha_oidc" {
   github_org            = "DaqulaLin"
   github_repo           = "terraform-aws-vpc-ec2-lab"
   region                = var.region
-  state_bucket_name     = "tfstate-160885250897-dev-1833551180"
+  state_bucket_name     = "my-terraform-state-daqula"
   state_lock_table_name = "tf-locks"
 
 

--- a/envs/dev/output.tf
+++ b/envs/dev/output.tf
@@ -1,9 +1,9 @@
 output "vpc_id" { value = module.vpc.vpc_id }
 output "public_subnet_ids" { value = module.vpc.public_subnet_ids }
 output "private_subnet_ids" { value = module.vpc.private_subnet_ids }
-#output "ec2_public_ip" { value = module.ec2.public_ip }
+output "ec2_public_ip" { value = module.ec2.public_ip }
 
-/*
+
 output "plan_role_arn" {
   value = module.iam_gha_oidc.plan_role_arn
 }
@@ -12,6 +12,18 @@ output "apply_role_arn" {
   value = module.iam_gha_oidc.apply_role_arn
 }
 
-output "alb_dns_name" { value = module.alb.alb_dns_name }
-output "rds_endpoint" { value = module.rds.endpoint }
-*/
+output "alb_dns_name" {
+  value       = var.enable_alb ? module.alb["main"].alb_dns_name : null
+  description = "ALB DNS name when enabled"
+
+}
+
+
+output "alb_sg_id" {
+  value       = var.enable_alb ? module.alb["main"].alb_sg_id : null
+  description = "ALB security group id when enabled"
+}
+
+
+
+#output "rds_endpoint" { value = module.rds.endpoint }

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -34,7 +34,7 @@ variable "rds_password" { type = string }
 
 variable "enable_alb" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "enable_rds" {

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -32,13 +32,6 @@ variable "rds_password" { type = string }
 
 
 
-
-variable "enable_ec2" {
-  type    = bool
-  default = false
-}
-
-
 variable "enable_alb" {
   type    = bool
   default = false

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -60,6 +60,7 @@ resource "aws_lb_target_group_attachment" "instances" {
 }
 
 # 方式二：挂 ASG（传入 asg_name 时启用）
+/*
 resource "aws_autoscaling_attachment" "asg" {
   count                  = var.asg_name == null ? 0 : 1
   autoscaling_group_name = var.asg_name
@@ -67,3 +68,4 @@ resource "aws_autoscaling_attachment" "asg" {
 
 
 }
+*/

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,3 +1,5 @@
+
+
 # 若未传 ami_id，则选 Amazon Linux 2023（x86_64）
 # If ami_id is not provided, select Amazon Linux 2023 (x86_64)
 data "aws_ami" "al2023" {

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -58,13 +58,14 @@ resource "aws_security_group" "web" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  */
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  */
+
 }
 
 # 启动即安装 Nginx（AL2023 用 dnf）

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "plan_policy" {
   statement {
     sid     = "S3StateRead"
     effect  = "Allow"
-    actions = ["s3:ListBucket", "s3:GetObject", "s3:GetObjectVersion"]
+    actions = ["s3:ListBucket", "s3:GetBucketLocation", "s3:GetObject", "s3:GetObjectVersion"]
     resources = [
       "arn:aws:s3:::${var.state_bucket_name}",
       "arn:aws:s3:::${var.state_bucket_name}/*"
@@ -65,7 +65,40 @@ data "aws_iam_policy_document" "plan_policy" {
     ]
     resources = ["*"]
   }
+  # 仅用于 plan 的读取权限（不会创建/修改）
+  statement {
+    sid       = "IAMReadOnly"
+    effect    = "Allow"
+    actions   = ["iam:Get*", "iam:List*"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "EC2ReadOnly"
+    effect    = "Allow"
+    actions   = ["ec2:Describe*"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "ELBReadOnly"
+    effect    = "Allow"
+    actions   = ["elasticloadbalancing:Describe*"]
+    resources = ["*"]
+  }
+  # 若后续 PR 会读 ASG/RDS，也一并加：
+  statement {
+    sid       = "ASGReadOnly"
+    effect    = "Allow"
+    actions   = ["autoscaling:Describe*"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "RDSReadOnly"
+    effect    = "Allow"
+    actions   = ["rds:Describe*"]
+    resources = ["*"]
+  }
 }
+
 
 resource "aws_iam_policy" "tf_plan" {
   name   = "tf-plan-read-state"


### PR DESCRIPTION
## What
- Add single EC2 instance wired to current VPC
- Keep original security group default (no ALB yet)
- SSM enabled, user-data installs Nginx

## How to verify
- GitHub Actions `plan` should show: create 5~8 resources (iam role/profile, sg, ec2, etc.)
- No changes to VPC/remote backend/iam_gha_oidc

## Rollback
- Revert this PR or run `terraform destroy -target=module.ec2`
